### PR TITLE
[ refactor: issue-16 ] imports sorting moved from prettier config to eslint

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,21 @@
  $ npm install -g pnpm
 ```
 
+### _Eslint & Prettier setup_ 👀
+
+In your `VSCode settings.json(cmd + ,)` paste these commands:
+
+```json
+"editor.defaultFormatter": "esbenp.prettier-vscode",
+"editor.formatOnSave": true,
+"editor.codeActionsOnSave": {
+    "source.fixAll.eslint": true,
+},
+```
+
+Config file where you can improve our eslint rules is `.eslintrc`.\
+We use recommended `plugins`.\
+The most of our `rules` are from the docs, but there is some from well known plugins e.g. for [sorting the imports](https://eslint.org/docs/latest/rules/sort-imports#membersyntaxsortorder) (`eslint-plugin-import` & `eslint-plugin-sort-imports-es6-autofix`) where you can see/learn the rules on this [link](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/order.md).
 <br/>
 
 ## Quick Start 🏃‍♂️

--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ In your `VSCode settings.json(cmd + ,)` paste these commands:
 
 Config file where you can improve our eslint rules is `.eslintrc`.\
 We use recommended `plugins`.\
-The most of our `rules` are from the docs, but there is some from well known plugins e.g. for [sorting the imports](https://eslint.org/docs/latest/rules/sort-imports#membersyntaxsortorder) (`eslint-plugin-import` & `eslint-plugin-sort-imports-es6-autofix`) where you can see/learn the rules on this [link](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/order.md).
+The most of our `rules` are from the docs, but there is some from well known plugins e.g. for sorting the imports (`eslint-plugin-import` & `eslint-plugin-sort-imports-es6-autofix`) where you can see/learn the rules on this [link](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/order.md).
+_Note_: do not mix rules from [`sort-imports`](https://eslint.org/docs/latest/rules/sort-imports#membersyntaxsortorder) (default eslint import sort rules) with [`eslint-plugin-import`](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/order.md) !!!
 <br/>
 
 ## Quick Start 🏃‍♂️

--- a/packages/client/.eslintrc
+++ b/packages/client/.eslintrc
@@ -7,6 +7,7 @@
     "plugin:prettier/recommended",
     "plugin:react-hooks/recommended"
   ],
+  "plugins": ["import"],
   "parserOptions": {
     "ecmaVersion": 2018,
     "sourceType": "module",
@@ -15,6 +16,13 @@
     }
   },
   "rules": {
+    "import/order": [
+      "error",
+      {
+        "groups": ["builtin", "external", "internal", "parent", "sibling", "index"],
+        "newlines-between": "always"
+      }
+    ],
     "dot-notation": 2,
     "no-const-assign": 2,
     "no-dupe-keys": 2,

--- a/packages/client/.eslintrc
+++ b/packages/client/.eslintrc
@@ -20,7 +20,11 @@
       2,
       {
         "groups": ["external", "internal", "builtin", ["parent", "sibling"], "index"],
-        "newlines-between": "always"
+        "newlines-between": "always",
+        "alphabetize": {
+          "order": "asc",
+          "caseInsensitive": true
+        }
       }
     ],
     "dot-notation": 2,

--- a/packages/client/.eslintrc
+++ b/packages/client/.eslintrc
@@ -17,9 +17,9 @@
   },
   "rules": {
     "import/order": [
-      "error",
+      2,
       {
-        "groups": ["builtin", "external", "internal", "parent", "sibling", "index"],
+        "groups": ["external", "internal", "builtin", ["parent", "sibling"], "index"],
         "newlines-between": "always"
       }
     ],

--- a/packages/client/.prettierrc
+++ b/packages/client/.prettierrc
@@ -2,8 +2,5 @@
   "trailingComma": "all",
   "singleQuote": true,
   "printWidth": 120,
-  "plugins": ["@trivago/prettier-plugin-sort-imports"],
-  "importOrder": ["^@core/(.*)$", "^@server/(.*)$", "^@ui/(.*)$", "^[./]"],
-  "importOrderSeparation": true,
-  "importOrderSortSpecifiers": true
+  "tabWidth": 2
 }

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -25,7 +25,6 @@
     "vite-plugin-eslint": "^1.8.1"
   },
   "devDependencies": {
-    "@trivago/prettier-plugin-sort-imports": "^4.1.1",
     "@types/react": "^18.0.28",
     "@types/react-dom": "^18.0.11",
     "@types/styled-components": "^5.1.26",
@@ -35,8 +34,10 @@
     "eslint": "^8.36.0",
     "eslint-config-prettier": "^8.8.0",
     "eslint-config-react-app": "^7.0.1",
+    "eslint-plugin-import": "^2.27.5",
     "eslint-plugin-prettier": "^4.2.1",
     "eslint-plugin-react-hooks": "^4.6.0",
+    "eslint-plugin-sort-imports-es6-autofix": "^0.6.0",
     "prettier": "^2.8.6",
     "typescript": "^4.9.5",
     "vite": "^4.2.0"

--- a/packages/client/src/components/card/Card.tsx
+++ b/packages/client/src/components/card/Card.tsx
@@ -1,6 +1,6 @@
+import { Avatar, ButtonWrapper, CardBody, CardContainer, CardHeader, CardInfo, DeleteButton } from './Card.styled';
 import CoverImage from '../../assets/avatar.jpg';
 import Button from '../button/Button';
-import { Avatar, ButtonWrapper, CardBody, CardContainer, CardHeader, CardInfo, DeleteButton } from './Card.styled';
 
 const Card = () => {
   // TODO: Replace mocked data with users from  the API, Instead of using Cover Image there will be avatar from the API

--- a/packages/client/src/pages/home-page/HomePage.tsx
+++ b/packages/client/src/pages/home-page/HomePage.tsx
@@ -1,5 +1,5 @@
-import Card from '../../components/card/Card';
 import { CardWrapper } from './HomePage.styled';
+import Card from '../../components/card/Card';
 
 // import { api } from './../../redux-toolkit/api';
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -46,9 +46,6 @@ importers:
         specifier: ^1.8.1
         version: 1.8.1(eslint@8.36.0)(vite@4.2.0)
     devDependencies:
-      '@trivago/prettier-plugin-sort-imports':
-        specifier: ^4.1.1
-        version: 4.1.1(prettier@2.8.6)
       '@types/react':
         specifier: ^18.0.28
         version: 18.0.28
@@ -76,12 +73,18 @@ importers:
       eslint-config-react-app:
         specifier: ^7.0.1
         version: 7.0.1(@babel/plugin-syntax-flow@7.21.4)(@babel/plugin-transform-react-jsx@7.21.0)(eslint@8.36.0)(typescript@4.9.5)
+      eslint-plugin-import:
+        specifier: ^2.27.5
+        version: 2.27.5(@typescript-eslint/parser@5.56.0)(eslint@8.36.0)
       eslint-plugin-prettier:
         specifier: ^4.2.1
         version: 4.2.1(eslint-config-prettier@8.8.0)(eslint@8.36.0)(prettier@2.8.6)
       eslint-plugin-react-hooks:
         specifier: ^4.6.0
         version: 4.6.0(eslint@8.36.0)
+      eslint-plugin-sort-imports-es6-autofix:
+        specifier: ^0.6.0
+        version: 0.6.0(eslint@8.36.0)
       prettier:
         specifier: ^2.8.6
         version: 2.8.6
@@ -191,15 +194,6 @@ packages:
       eslint: 8.36.0
       eslint-visitor-keys: 2.1.0
       semver: 6.3.0
-    dev: true
-
-  /@babel/generator@7.17.7:
-    resolution: {integrity: sha512-oLcVCTeIFadUoArDTwpluncplrYBmTCCZZgXCbgNGvOBBiSDDK3eWO4b/+eOTli5tKv1lg+a5/NAXg+nTcei1w==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/types': 7.21.4
-      jsesc: 2.5.2
-      source-map: 0.5.7
     dev: true
 
   /@babel/generator@7.21.4:
@@ -1468,24 +1462,6 @@ packages:
       '@babel/parser': 7.21.4
       '@babel/types': 7.21.4
 
-  /@babel/traverse@7.17.3:
-    resolution: {integrity: sha512-5irClVky7TxRWIRtxlh2WPUUOLhcPN06AGgaQSB8AEwuyEBgJVuJ5imdHm5zxk8w0QS5T+tDfnDxAlhWjpb7cw==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/code-frame': 7.21.4
-      '@babel/generator': 7.21.4
-      '@babel/helper-environment-visitor': 7.18.9
-      '@babel/helper-function-name': 7.21.0
-      '@babel/helper-hoist-variables': 7.18.6
-      '@babel/helper-split-export-declaration': 7.18.6
-      '@babel/parser': 7.21.4
-      '@babel/types': 7.21.4
-      debug: 4.3.4(supports-color@5.5.0)
-      globals: 11.12.0
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
   /@babel/traverse@7.21.4(supports-color@5.5.0):
     resolution: {integrity: sha512-eyKrRHKdyZxqDm+fV1iqL9UAHMoIg0nDaGqfIOd8rKH17m5snv7Gn4qgjBoFfLz9APvjFU/ICT00NVCv1Epp8Q==}
     engines: {node: '>=6.9.0'}
@@ -1502,14 +1478,6 @@ packages:
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
-
-  /@babel/types@7.17.0:
-    resolution: {integrity: sha512-TmKSNO4D5rzhL5bjWFcVHHLETzfQ/AmbKpKPOSjlP0WoHZ6L911fgoOKY4Alp/emzG4cHJdyN49zpgkbXFEHHw==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/helper-validator-identifier': 7.19.1
-      to-fast-properties: 2.0.0
-    dev: true
 
   /@babel/types@7.21.4:
     resolution: {integrity: sha512-rU2oY501qDxE8Pyo7i/Orqma4ziCOrby0/9mvbDUGEfvZjb279Nk9k19e2fiCxHbRRpY2ZyrgW1eq22mvmOIzA==}
@@ -1913,26 +1881,6 @@ packages:
       react-dom: 18.2.0(react@18.2.0)
       use-sync-external-store: 1.2.0(react@18.2.0)
     dev: false
-
-  /@trivago/prettier-plugin-sort-imports@4.1.1(prettier@2.8.6):
-    resolution: {integrity: sha512-dQ2r2uzNr1x6pJsuh/8x0IRA3CBUB+pWEW3J/7N98axqt7SQSm+2fy0FLNXvXGg77xEDC7KHxJlHfLYyi7PDcw==}
-    peerDependencies:
-      '@vue/compiler-sfc': 3.x
-      prettier: 2.x
-    peerDependenciesMeta:
-      '@vue/compiler-sfc':
-        optional: true
-    dependencies:
-      '@babel/generator': 7.17.7
-      '@babel/parser': 7.21.4
-      '@babel/traverse': 7.17.3
-      '@babel/types': 7.17.0
-      javascript-natural-sort: 0.7.1
-      lodash: 4.17.21
-      prettier: 2.8.6
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
 
   /@trpc/client@10.18.0(@trpc/server@10.18.0):
     resolution: {integrity: sha512-2d+6r2C/xygTjDWX9jT66defgHzbQP0Z8vrvyT3XtPjqU6JNlRNuS2ZtB8xDPdOQUUVnndzZ43BMr+Zu49K0OQ==}
@@ -3268,6 +3216,14 @@ packages:
       string.prototype.matchall: 4.0.8
     dev: true
 
+  /eslint-plugin-sort-imports-es6-autofix@0.6.0(eslint@8.36.0):
+    resolution: {integrity: sha512-2NVaBGF9NN+727Fyq+jJYihdIeegjXeUUrZED9Q8FVB8MsV3YQEyXG96GVnXqWt0pmn7xfCZOZf3uKnIhBrfeQ==}
+    peerDependencies:
+      eslint: '>=7.7.0'
+    dependencies:
+      eslint: 8.36.0
+    dev: true
+
   /eslint-plugin-testing-library@5.10.2(eslint@8.36.0)(typescript@4.9.5):
     resolution: {integrity: sha512-f1DmDWcz5SDM+IpCkEX0lbFqrrTs8HRsEElzDEqN/EBI0hpRj8Cns5+IVANXswE8/LeybIJqPAOQIFu2j5Y5sw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0, npm: '>=6'}
@@ -3901,10 +3857,6 @@ packages:
 
   /isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
-
-  /javascript-natural-sort@0.7.1:
-    resolution: {integrity: sha512-nO6jcEfZWQXDhOiBtG2KvKyEptz7RVbpGP4vTD2hLBdmNQSsCiicO2Ioinv6UI4y9ukqnBpy+XZ9H6uLNgJTlw==}
-    dev: true
 
   /js-sdsl@4.4.0:
     resolution: {integrity: sha512-FfVSdx6pJ41Oa+CF7RDaFmTnCaFhua+SNYQX74riGOpl96x+2jQCqEfQ2bnXu/5DPCqlRuiqyvTJM0Qjz26IVg==}
@@ -4679,11 +4631,6 @@ packages:
     dependencies:
       buffer-from: 1.1.2
       source-map: 0.6.1
-    dev: true
-
-  /source-map@0.5.7:
-    resolution: {integrity: sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==}
-    engines: {node: '>=0.10.0'}
     dev: true
 
   /source-map@0.6.1:


### PR DESCRIPTION
- @trivago/prettier-plugin-sort-imports removed
- eslint-plugin-import & eslint-plugin-sort-imports-es6-autofix introduced
- README file updated